### PR TITLE
Add -g, --global CLI flag to run with global config and bypass project config (CFG-56)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -11,6 +11,7 @@ Gaunt Sloth provides several commands to help with code review, analysis, and in
 Every command supports these shared flags:
 
 - `--config <path>` – load a specific configuration file (without changing directories); accepts any supported config format (`.json`, `.jsonc`, `.js`, `.mjs`)
+- `-g, --global` – run under `~/.gsloth/` only, ignoring the project's config (see [The global config and your project config](configuration/index.md#the-global-config-and-your-project-config)); cannot be combined with `--config`
 - `-i, --identity-profile <name>` – use prompts/configs from `.gsloth/.gsloth-settings/<name>/`
 - `-w, --write-output-to-file <value>` – control output files (`false` by default, pass `true` for standard names, `-wn`/`-w0` for false, or a relative filename)
 - `--verbose` – enable verbose LangChain/LangGraph logs for troubleshooting

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -83,10 +83,10 @@ chain.
 
 ### Run under the global config only
 
-`-g`/`--global` drops the project layer instead: discovery does not walk up from the working
-directory, and the run resolves from `~/.gsloth/` alone. Use it when you are working inside someone
-else's repository — or a machine-generated one — and want your own provider, model and approvals
-rather than whatever that project configures:
+`-g`/`--global` drops the project layer instead: config discovery does not walk up from the working
+directory, and configuration resolves from `~/.gsloth/` alone. Use it when you want a run to use
+your own configuration — provider, model, tools, approvals — rather than whatever the repository
+you are standing in configures:
 
 ```bash
 gth -g review
@@ -100,8 +100,10 @@ project's, and fails if you have no global `devops` profile:
 gth -g -i devops pr 42
 ```
 
-Prompt files ([guidelines, review checklist and the rest](prompts.md)) are unaffected by `-g`: they
-resolve from the working directory as usual, and fall back to the built-in defaults.
+`-g` scopes **configuration** only; it is not a boundary around the project directory. Prompt files
+([guidelines, review checklist and the rest](prompts.md)) still resolve from the working directory
+as usual, falling back to the built-in defaults — so a project's own guidelines or review prompt are
+read into the prompt under `-g` just as they are without it.
 
 `-g` and `-c` cannot be combined: both choose where configuration comes from, so passing the pair
 is rejected rather than silently honouring one of them.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -81,6 +81,31 @@ and neither `-c`/`--config` nor `-i`/`--identity-profile` (`--profile`) bypasses
 [Identity profiles](profiles.md#identity-profiles) for where a profile sits in the full precedence
 chain.
 
+### Run under the global config only
+
+`-g`/`--global` drops the project layer instead: discovery does not walk up from the working
+directory, and the run resolves from `~/.gsloth/` alone. Use it when you are working inside someone
+else's repository — or a machine-generated one — and want your own provider, model and approvals
+rather than whatever that project configures:
+
+```bash
+gth -g review
+```
+
+With `-i`/`--profile`, the named profile's config is resolved globally too, from
+`~/.gsloth/.gsloth-settings/<name>/` — so this reads your own `devops` config and never the
+project's, and fails if you have no global `devops` profile:
+
+```bash
+gth -g -i devops pr 42
+```
+
+Prompt files ([guidelines, review checklist and the rest](prompts.md)) are unaffected by `-g`: they
+resolve from the working directory as usual, and fall back to the built-in defaults.
+
+`-g` and `-c` cannot be combined: both choose where configuration comes from, so passing the pair
+is rejected rather than silently honouring one of them.
+
 To see what a run actually resolves to, print the effective merged config; to find which file to fix
 when a key is wrong, validate each layer on its own:
 

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -86,6 +86,13 @@ back to some other config — not to your global `~/.gsloth` config, and not to 
 plain `.gsloth.config.*` either, which is the fallback you would otherwise get and the surprising
 one. A mistyped `-i` therefore tells you so, instead of running under a model you did not choose.
 
+**Where a profile is looked up.** By default, in the project: `.gsloth/.gsloth-settings/<name>/`,
+searched from the working directory up to the repository root. Add
+[`-g`/`--global`](index.md#run-under-the-global-config-only) and the same name is looked up in
+`~/.gsloth/.gsloth-settings/<name>/` instead — your own profiles, in a repository that knows nothing
+about them. The two are separate namespaces: a profile that exists only in the project is not found
+under `-g`, and vice versa.
+
 ### Creating a profile
 
 `gth config profile create <name>` scaffolds a new profile directory

--- a/packages/app/spec/cliGlobalFlag.spec.ts
+++ b/packages/app/spec/cliGlobalFlag.spec.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+import type { CommandLineConfigOverrides } from '@gaunt-sloth/core/config.js';
+
+describe('CLI -g / --global option parsing', () => {
+  const parseCli = (argv: string[]): CommandLineConfigOverrides => {
+    const program = new Command();
+    program
+      .name('gth')
+      .option('-c, --config <path>', 'Path to custom configuration file')
+      .option('-g, --global', 'Run with global configuration, bypassing project-level config')
+      .option('-i, --identity-profile <identity>', 'Identity profile')
+      .option('--profile <name>', 'Named config profile');
+
+    const cliConfigOverrides: CommandLineConfigOverrides = {};
+    program.parseOptions(argv);
+
+    if (program.getOptionValue('config')) {
+      cliConfigOverrides.customConfigPath = program.getOptionValue('config');
+    }
+    if (program.getOptionValue('global')) {
+      cliConfigOverrides.global = true;
+    }
+    const profile = program.getOptionValue('profile') ?? program.getOptionValue('identityProfile');
+    if (profile) {
+      cliConfigOverrides.identityProfile = profile;
+    }
+    return cliConfigOverrides;
+  };
+
+  it('sets global = true when -g is passed', () => {
+    const overrides = parseCli(['node', 'gth', '-g', 'config', 'print']);
+    expect(overrides.global).toBe(true);
+  });
+
+  it('sets global = true when --global is passed', () => {
+    const overrides = parseCli(['node', 'gth', '--global', 'config', 'validate']);
+    expect(overrides.global).toBe(true);
+  });
+
+  it('leaves global undefined when neither flag is passed', () => {
+    const overrides = parseCli(['node', 'gth', 'config', 'print']);
+    expect(overrides.global).toBeUndefined();
+  });
+
+  it('composes --global with -i / --profile', () => {
+    const overrides = parseCli(['node', 'gth', '-g', '-i', 'myprofile', 'ask', 'hello']);
+    expect(overrides.global).toBe(true);
+    expect(overrides.identityProfile).toBe('myprofile');
+  });
+});

--- a/packages/app/spec/cliGlobalFlag.spec.ts
+++ b/packages/app/spec/cliGlobalFlag.spec.ts
@@ -1,51 +1,103 @@
-import { Command } from 'commander';
-import { describe, expect, it } from 'vitest';
-import type { CommandLineConfigOverrides } from '@gaunt-sloth/core/config.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-describe('CLI -g / --global option parsing', () => {
-  const parseCli = (argv: string[]): CommandLineConfigOverrides => {
-    const program = new Command();
-    program
-      .name('gth')
-      .option('-c, --config <path>', 'Path to custom configuration file')
-      .option('-g, --global', 'Run with global configuration, bypassing project-level config')
-      .option('-i, --identity-profile <identity>', 'Identity profile')
-      .option('--profile <name>', 'Named config profile');
+/**
+ * CFG-56 — coverage of the REAL `-g`/`--global` option as `packages/app/src/cli.ts` declares it.
+ *
+ * `cli.ts` parses argv and dispatches at module load, so there is no exported parser to call: the
+ * option definition is only observable by running the built CLI. Every assertion here therefore
+ * goes through the binary, which is what makes removing or renaming the flag in `cli.ts` turn this
+ * file red. Requires the app build (`pnpm test` builds before vitest runs); `--nopipe` makes the
+ * CLI parse immediately instead of waiting on stdin.
+ *
+ * `configValidate.e2e.spec.ts` covers `-g` bypassing a broken project config and the `-g`/`-c`
+ * refusal; what is asserted here is the flag's own declaration and its interaction with
+ * `-i`/`--identity-profile`, which resolves under `~/.gsloth/.gsloth-settings/<name>/` only under
+ * `-g`.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const cliEntry = resolve(here, '../cli.js'); // packages/app/cli.js (sets install dir, loads dist)
 
-    const cliConfigOverrides: CommandLineConfigOverrides = {};
-    program.parseOptions(argv);
+function runCli(
+  args: string[],
+  options?: { cwd?: string; env?: Record<string, string> }
+): { status: number | null; output: string } {
+  const env = { ...process.env, ...options?.env };
+  if (!options?.env?.INIT_CWD) {
+    delete env.INIT_CWD;
+  }
+  const result = spawnSync('node', [cliEntry, '--nopipe', ...args], {
+    encoding: 'utf8',
+    cwd: options?.cwd ?? tmpdir(),
+    env,
+  });
+  return { status: result.status, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
 
-    if (program.getOptionValue('config')) {
-      cliConfigOverrides.customConfigPath = program.getOptionValue('config');
-    }
-    if (program.getOptionValue('global')) {
-      cliConfigOverrides.global = true;
-    }
-    const profile = program.getOptionValue('profile') ?? program.getOptionValue('identityProfile');
-    if (profile) {
-      cliConfigOverrides.identityProfile = profile;
-    }
-    return cliConfigOverrides;
+describe('gth -g / --global (real CLI definition)', () => {
+  let dir: string;
+  let projectDir: string;
+  let homeDir: string;
+  // `os.homedir()` reads HOME on POSIX and USERPROFILE on win32, so a fake home must set BOTH or
+  // the spawned CLI resolves ~/.gsloth to the real profile dir on the Windows CI cells.
+  let fakeHome: Record<string, string>;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), 'gsloth-global-cli-'));
+    projectDir = resolve(dir, 'proj');
+    homeDir = resolve(dir, 'home');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(resolve(homeDir, '.gsloth'), { recursive: true });
+    fakeHome = { HOME: homeDir, USERPROFILE: homeDir };
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeGlobalProfileConfig = (profile: string, content: string) => {
+    const profileDir = resolve(homeDir, '.gsloth', '.gsloth-settings', profile);
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(resolve(profileDir, '.gsloth.config.json'), content);
   };
 
-  it('sets global = true when -g is passed', () => {
-    const overrides = parseCli(['node', 'gth', '-g', 'config', 'print']);
-    expect(overrides.global).toBe(true);
+  it('declares -g, --global in its help output', () => {
+    const { status, output } = runCli(['--help']);
+    expect(status).toBe(0);
+    expect(output).toContain('-g, --global');
   });
 
-  it('sets global = true when --global is passed', () => {
-    const overrides = parseCli(['node', 'gth', '--global', 'config', 'validate']);
-    expect(overrides.global).toBe(true);
+  it('resolves an identity profile under the global settings dir when -g is passed', () => {
+    writeFileSync(
+      resolve(projectDir, '.gsloth.config.json'),
+      '{"llm":{"type":"openai"},"streamOutput":"yes"}'
+    );
+    writeGlobalProfileConfig('devops', '{"llm":{"type":"openai"}}');
+
+    const { status, output } = runCli(['-g', '-i', 'devops', 'config', 'validate'], {
+      cwd: projectDir,
+      env: fakeHome,
+    });
+
+    expect(status).toBe(0);
+    expect(output).toContain('Configuration is valid');
+    // The layer label names the file that was read: the profile's config under ~/.gsloth.
+    expect(output).toContain('.gsloth-settings/devops/.gsloth.config.json (global)');
   });
 
-  it('leaves global undefined when neither flag is passed', () => {
-    const overrides = parseCli(['node', 'gth', 'config', 'print']);
-    expect(overrides.global).toBeUndefined();
-  });
+  it('does not resolve a globally-defined identity profile without -g', () => {
+    writeGlobalProfileConfig('devops', '{"llm":{"type":"openai"}}');
 
-  it('composes --global with -i / --profile', () => {
-    const overrides = parseCli(['node', 'gth', '-g', '-i', 'myprofile', 'ask', 'hello']);
-    expect(overrides.global).toBe(true);
-    expect(overrides.identityProfile).toBe('myprofile');
+    const { status, output } = runCli(['-i', 'devops', 'config', 'validate'], {
+      cwd: projectDir,
+      env: fakeHome,
+    });
+
+    expect(status).not.toBe(0);
+    expect(output).toContain('identity profile "devops" not found');
   });
 });

--- a/packages/app/spec/configValidate.e2e.spec.ts
+++ b/packages/app/spec/configValidate.e2e.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -81,8 +81,7 @@ describe('gth config validate — process exit code (e2e)', () => {
     expect(status).not.toBe(0);
   });
 
-  it('bypasses a broken project config and validates global config when -g is passed', async () => {
-    const { mkdirSync } = await import('node:fs');
+  it('bypasses a broken project config and validates global config when -g is passed', () => {
     // Project dir with a malformed/invalid config
     const projDir = fixture('proj', '');
     rmSync(projDir, { recursive: true, force: true });
@@ -118,7 +117,14 @@ describe('gth config validate — process exit code (e2e)', () => {
 
   it('refuses -g together with -c instead of silently ignoring one of them', () => {
     const cfg = fixture('named.json', '{"llm":{"type":"openai"}}');
-    const { status, stdout, stderr } = runCli(['-g', '-c', cfg, 'config', 'validate']);
+    // Faked home like its neighbour: the conflict guard fires before any config is read, so the
+    // runner's real ~/.gsloth is never consulted today — but a spawned `-g` run must not depend on
+    // the machine it runs on for that to stay true.
+    const homeDir = resolve(dir, 'conflict-home');
+    mkdirSync(resolve(homeDir, '.gsloth'), { recursive: true });
+    const { status, stdout, stderr } = runCli(['-g', '-c', cfg, 'config', 'validate'], {
+      env: { HOME: homeDir, USERPROFILE: homeDir },
+    });
     expect(status).not.toBe(0);
     const output = `${stdout}${stderr}`;
     expect(output).toContain('--global');

--- a/packages/app/spec/configValidate.e2e.spec.ts
+++ b/packages/app/spec/configValidate.e2e.spec.ts
@@ -14,11 +14,20 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const cliEntry = resolve(here, '../cli.js'); // packages/app/cli.js (sets install dir, loads dist)
 
-function runCli(args: string[]): { status: number | null; stdout: string; stderr: string } {
+function runCli(
+  args: string[],
+  options?: { cwd?: string; env?: Record<string, string> }
+): { status: number | null; stdout: string; stderr: string } {
+  const targetCwd = options?.cwd ?? tmpdir();
+  const env = { ...process.env, ...options?.env };
+  if (!options?.env?.INIT_CWD) {
+    delete env.INIT_CWD;
+  }
   const result = spawnSync('node', [cliEntry, '--nopipe', ...args], {
     encoding: 'utf8',
     // Absolute --config paths make cwd irrelevant; a temp cwd keeps any incidental writes contained.
-    cwd: tmpdir(),
+    cwd: targetCwd,
+    env,
   });
   return { status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
 }
@@ -70,5 +79,36 @@ describe('gth config validate — process exit code (e2e)', () => {
     const cfg = fixture('broken.json', '{"llm": {"type": "openai" ');
     const { status } = runCli(['-c', cfg, 'config', 'validate']);
     expect(status).not.toBe(0);
+  });
+
+  it('bypasses a broken project config and validates global config when -g is passed', async () => {
+    const { mkdirSync } = await import('node:fs');
+    // Project dir with a malformed/invalid config
+    const projDir = fixture('proj', '');
+    rmSync(projDir, { recursive: true, force: true });
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(
+      resolve(projDir, '.gsloth.config.json'),
+      '{"llm":{"type":"openai"},"streamOutput":"yes"}'
+    );
+
+    // Global dir in fake HOME
+    const homeDir = fixture('home', '');
+    rmSync(homeDir, { recursive: true, force: true });
+    const globalGsloth = resolve(homeDir, '.gsloth');
+    mkdirSync(globalGsloth, { recursive: true });
+    writeFileSync(resolve(globalGsloth, '.gsloth.config.json'), '{"llm":{"type":"openai"}}');
+
+    // Without -g: validates project config and fails
+    const failRes = runCli(['config', 'validate'], { cwd: projDir, env: { HOME: homeDir } });
+    expect(failRes.status).not.toBe(0);
+
+    // With -g: validates global config only and succeeds (exit 0)
+    const successRes = runCli(['-g', 'config', 'validate'], {
+      cwd: projDir,
+      env: { HOME: homeDir },
+    });
+    expect(successRes.status).toBe(0);
+    expect(`${successRes.stdout}${successRes.stderr}`).toContain('Configuration is valid');
   });
 });

--- a/packages/app/spec/configValidate.e2e.spec.ts
+++ b/packages/app/spec/configValidate.e2e.spec.ts
@@ -99,16 +99,31 @@ describe('gth config validate — process exit code (e2e)', () => {
     mkdirSync(globalGsloth, { recursive: true });
     writeFileSync(resolve(globalGsloth, '.gsloth.config.json'), '{"llm":{"type":"openai"}}');
 
+    // `os.homedir()` reads HOME on POSIX and USERPROFILE on win32, so a fake home must set BOTH
+    // or the spawned CLI resolves ~/.gsloth to the real profile dir on the Windows CI cells.
+    const fakeHome = { HOME: homeDir, USERPROFILE: homeDir };
+
     // Without -g: validates project config and fails
-    const failRes = runCli(['config', 'validate'], { cwd: projDir, env: { HOME: homeDir } });
+    const failRes = runCli(['config', 'validate'], { cwd: projDir, env: fakeHome });
     expect(failRes.status).not.toBe(0);
 
     // With -g: validates global config only and succeeds (exit 0)
     const successRes = runCli(['-g', 'config', 'validate'], {
       cwd: projDir,
-      env: { HOME: homeDir },
+      env: fakeHome,
     });
     expect(successRes.status).toBe(0);
     expect(`${successRes.stdout}${successRes.stderr}`).toContain('Configuration is valid');
+  });
+
+  it('refuses -g together with -c instead of silently ignoring one of them', () => {
+    const cfg = fixture('named.json', '{"llm":{"type":"openai"}}');
+    const { status, stdout, stderr } = runCli(['-g', '-c', cfg, 'config', 'validate']);
+    expect(status).not.toBe(0);
+    const output = `${stdout}${stderr}`;
+    expect(output).toContain('--global');
+    expect(output).toContain('--config');
+    // The named file must not have been loaded and reported valid.
+    expect(output).not.toContain('Configuration is valid');
   });
 });

--- a/packages/app/spec/firstRunDialog.spec.ts
+++ b/packages/app/spec/firstRunDialog.spec.ts
@@ -212,6 +212,29 @@ describe('runFirstRunDialog', () => {
     });
   });
 
+  it('writes global config without asking about scope when the caller forces it', async () => {
+    // CFG-56 — `gth -g` reads global config only. Asking the scope question there offers a project
+    // default that writes a file the run will not look at, and the session then reports that setup
+    // did not complete — on every retry.
+    deps.detectProviders = vi
+      .fn()
+      .mockResolvedValue([
+        provider({ id: 'openai', available: true, apiKeyEnvironmentVariable: 'OPENAI_API_KEY' }),
+      ]);
+    deps.fetchModels = vi
+      .fn()
+      .mockResolvedValue({ models: [model('gpt-4o', true)], status: 'live' });
+    // provider + model only; a scope prompt would consume a third entry and desynchronise this.
+    const select = vi.fn(scriptedSelect([0, undefined]));
+    deps.select = select;
+
+    await runFirstRunDialog(deps, false, 'global');
+
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(ensureGslothDir).not.toHaveBeenCalled();
+    expect(writeConfig.mock.calls[0][0]).toBe('global');
+  });
+
   it('still writes config for an unavailable provider so the user can fill in the key', async () => {
     deps.detectProviders = vi
       .fn()

--- a/packages/app/spec/modules/startSession.spec.ts
+++ b/packages/app/spec/modules/startSession.spec.ts
@@ -154,6 +154,28 @@ describe('startSession dispatcher', () => {
     expect(interactiveSessionMock.createInteractiveSession).not.toHaveBeenCalled();
   });
 
+  it('CFG-56: pins the dialog to the global scope under --global', async () => {
+    // Left to the dialog's project default, `gth -g` would write a config the run cannot see, fail
+    // the re-check below and report incomplete setup on every retry.
+    configMock.hasAnyConfig.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    loadInkMock.isInkAvailable.mockResolvedValue(false);
+
+    const { startSession } = await import('#src/modules/startSession.js');
+    await startSession(sessionConfig, { global: true }, undefined);
+
+    expect(firstRunDialogMock.runFirstRunDialog).toHaveBeenCalledWith({}, false, 'global');
+  });
+
+  it('CFG-56: leaves the scope to the user without --global', async () => {
+    configMock.hasAnyConfig.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    loadInkMock.isInkAvailable.mockResolvedValue(false);
+
+    const { startSession } = await import('#src/modules/startSession.js');
+    await startSession(sessionConfig, {}, undefined);
+
+    expect(firstRunDialogMock.runFirstRunDialog).toHaveBeenCalledWith({}, false, undefined);
+  });
+
   it('CFG-16: does NOT run the dialog (no auto-launch) on a non-TTY (piped) run', async () => {
     systemUtilsMock.stdin.isTTY = false;
     configMock.hasAnyConfig.mockResolvedValue(false);

--- a/packages/app/spec/modules/startSession.tuiConfig.spec.ts
+++ b/packages/app/spec/modules/startSession.tuiConfig.spec.ts
@@ -22,7 +22,8 @@ const loadInkMock = { isInkAvailable: vi.fn() };
 vi.mock('#src/tui/loadInk.js', () => loadInkMock);
 
 const { getGlobalGslothConfigReadPathMock } = vi.hoisted(() => ({
-  getGlobalGslothConfigReadPathMock: vi.fn<(_filename: string) => string>(),
+  getGlobalGslothConfigReadPathMock:
+    vi.fn<(_filename: string, _identityProfile?: string) => string>(),
 }));
 vi.mock('@gaunt-sloth/core/utils/globalConfigUtils.js', async (importOriginal) => {
   const actual =
@@ -59,8 +60,12 @@ describe('startSession reads the tui config key off disk (CFG-37 wiring)', () =>
     projectDir = resolve(root, 'proj');
     mkdirSync(resolve(projectDir, '.git'), { recursive: true });
     process.env.INIT_CWD = projectDir;
-    getGlobalGslothConfigReadPathMock.mockImplementation((filename: string) =>
-      resolve(globalDir, filename)
+    // Redirect the global dir ONLY; the profile-segment rule stays production code, so a
+    // profile-scoped global lookup cannot silently resolve to the unscoped path here.
+    const { resolveGlobalConfigPath } =
+      await import('@gaunt-sloth/core/utils/globalConfigUtils.js');
+    getGlobalGslothConfigReadPathMock.mockImplementation((filename, identityProfile) =>
+      resolveGlobalConfigPath(globalDir, filename, identityProfile)
     );
 
     // Declare the terminal rather than inherit the runner's: systemUtils re-exports the live

--- a/packages/app/src/cli.ts
+++ b/packages/app/src/cli.ts
@@ -77,7 +77,17 @@ if (program.getOptionValue('config')) {
   // Set a custom config path
   cliConfigOverrides.customConfigPath = program.getOptionValue('config');
 }
+// CFG-56 — `-g/--global` and `-c/--config` both choose WHERE configuration comes from, and
+// honouring either one makes the other a silent no-op. Refuse the pair here, before anything is
+// read, rather than quietly loading one source while the user watches for the other.
 if (program.getOptionValue('global')) {
+  if (cliConfigOverrides.customConfigPath) {
+    displayError(
+      '--global and --config select conflicting configuration sources ' +
+        '(the global config in ~/.gsloth versus the named file). Pass only one.'
+    );
+    exit(1);
+  }
   cliConfigOverrides.global = true;
 }
 // `--profile` (GS2-33) is the friendly alias of `-i/--identity-profile`: both select a named profile

--- a/packages/app/src/cli.ts
+++ b/packages/app/src/cli.ts
@@ -41,6 +41,7 @@ program
       'Consider using debugLog from config.ts for less intrusive debug logging.'
   )
   .option('-c, --config <path>', 'Path to custom configuration file')
+  .option('-g, --global', 'Run with global configuration, bypassing project-level config')
   .option('-i, --identity-profile <identity>', 'Identity profile (separate config and prompts)')
   .option(
     '--profile <name>',
@@ -75,6 +76,9 @@ if (program.getOptionValue('verbose')) {
 if (program.getOptionValue('config')) {
   // Set a custom config path
   cliConfigOverrides.customConfigPath = program.getOptionValue('config');
+}
+if (program.getOptionValue('global')) {
+  cliConfigOverrides.global = true;
 }
 // `--profile` (GS2-33) is the friendly alias of `-i/--identity-profile`: both select a named profile
 // block (`.gsloth/.gsloth-settings/<name>/`). If BOTH are given and disagree, that is a mistake worth

--- a/packages/app/src/commands/firstRunDialog.ts
+++ b/packages/app/src/commands/firstRunDialog.ts
@@ -255,7 +255,8 @@ export function makeDefaultProgress(): <T>(label: string, run: () => Promise<T>)
  */
 export async function runFirstRunDialog(
   overrides: Partial<FirstRunDialogDeps> = {},
-  force = false
+  force = false,
+  forcedScope?: ConfigScope
 ): Promise<void> {
   // The readline interface is created LAZILY, only when a readline prompt is actually needed
   // (the non-TTY number-menu fallback, or free-text model entry). On the Ink-select path it is
@@ -335,15 +336,18 @@ export async function runFirstRunDialog(
           .id;
     }
 
-    // 3. Scope.
+    // 3. Scope. CFG-56 — a caller that has already committed to a scope (`gth -g`, which reads
+    //    global config only) does not ask: the project default would write a file the run then
+    //    refuses to look at, and the user would be told setup did not complete.
     const scope: ConfigScope =
-      (await deps.select(
+      forcedScope ??
+      ((await deps.select(
         'Where should this configuration be stored?',
         ['This project only (.gsloth/.gsloth-settings/)', 'Globally for all projects (~/.gsloth/)'],
         0
       )) === 1
         ? 'global'
-        : 'project';
+        : 'project');
 
     // 4. Overwrite guard. If a config already exists at the chosen scope's path and the user did
     //    not pass --force, ask whether to overwrite (default No). On No we keep the existing file

--- a/packages/app/src/modules/startSession.ts
+++ b/packages/app/src/modules/startSession.ts
@@ -46,7 +46,10 @@ export async function startSession(
     // Imported lazily so the first-run dialog (and its provider-discovery/Ink deps) never
     // load on the normal configured path.
     const { runFirstRunDialog } = await import('#src/commands/firstRunDialog.js');
-    await runFirstRunDialog();
+    // CFG-56 — under `--global` the session reads global config only, so the dialog must write
+    // there. Left to its project default it would write a config this run cannot see, fail the
+    // re-check below, and report incomplete setup on every retry.
+    await runFirstRunDialog({}, false, commandLineConfigOverrides.global ? 'global' : undefined);
     if (!(await hasAnyConfig(commandLineConfigOverrides))) {
       // The user aborted the dialog without writing a config; nothing to run.
       displayWarning('Setup was not completed. Re-run gth once a configuration exists.');

--- a/packages/core/spec/config.globalFlag.spec.ts
+++ b/packages/core/spec/config.globalFlag.spec.ts
@@ -354,5 +354,31 @@ describe('CFG-56: -g / --global flag (bypass project config)', () => {
         `${resolve(globalRoot, '.gsloth-settings', 'safety')}${sep}`
       );
     });
+
+    it("names the global profile directory in validateConfig's own rater message", async () => {
+      // The case above asserts on the message initConfig throws. `validateConfig` builds its own
+      // rater message through the schema's `describeProfileDir` hook, so the directory it names is
+      // a separate code path — and the one `gth -g config validate` prints. Without the hook it
+      // falls back to the PROJECT directory and sends the user to a place nothing searched.
+      writeProjectProfileConfig('safety', { llm: { type: 'vertexai', model: 'project-safety' } });
+      writeGlobalConfig({
+        llm: { type: 'vertexai', model: 'global-model' },
+        approvals: { rater: 'safety' },
+      });
+
+      const { validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({ global: true });
+      expect(report.ok).toBe(false);
+      // Under `--global` the project layer is skipped, so the global layer is the only one.
+      const globalLayer = report.layers.find((layer) => layer.sourceLabel.includes('(global)'));
+      expect(globalLayer).toBeDefined();
+      expect(globalLayer!.errorMessage).toContain('identity profile "safety" not found');
+      // An absolute path under the fake home: the project fallback `.gsloth/.gsloth-settings/
+      // safety/` is a suffix of it, so only the home-rooted form can satisfy this.
+      expect(globalLayer!.errorMessage).toContain(
+        `${resolve(globalRoot, '.gsloth-settings', 'safety')}${sep}`
+      );
+    });
   });
 });

--- a/packages/core/spec/config.globalFlag.spec.ts
+++ b/packages/core/spec/config.globalFlag.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { isConfigDiscoveryError } from '#src/config/configDiscovery.js';
 
 const consoleUtilsMock = {
@@ -32,38 +32,30 @@ vi.mock('#src/utils/systemUtils.js', async (importOriginal) => {
   };
 });
 
-// Override getGlobalGslothDir and getGlobalGslothConfigReadPath to a dedicated temp global dir.
-const globalDirMock = {
-  dir: '',
-};
-vi.mock('#src/utils/globalConfigUtils.js', async () => {
-  const actual = await vi.importActual<typeof import('#src/utils/globalConfigUtils.js')>(
-    '#src/utils/globalConfigUtils.js'
-  );
-  return {
-    ...actual,
-    getGlobalGslothDir: () => globalDirMock.dir,
-    getGlobalGslothConfigReadPath: (filename: string, identityProfile?: string) => {
-      const p = identityProfile?.trim();
-      if (p) {
-        return resolve(globalDirMock.dir, '.gsloth-settings', p, filename);
-      }
-      return resolve(globalDirMock.dir, filename);
-    },
-  };
+// The home dir is the ONLY seam faked here, so `getGlobalGslothDir` and
+// `getGlobalGslothConfigReadPath` run for real — including the `.gsloth-settings/<profile>/`
+// segment this node adds. Faking the resolver instead would test a reimplementation of that rule
+// and could not tell the profile-scoped lookup from the plain one.
+const homeDirMock = { dir: '' };
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => homeDirMock.dir };
 });
 
 describe('CFG-56: -g / --global flag (bypass project config)', () => {
   let projectRoot: string;
+  let homeRoot: string;
   let globalRoot: string;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectDir = undefined;
     projectRoot = mkdtempSync(resolve(tmpdir(), 'gsloth-project-'));
-    globalRoot = mkdtempSync(resolve(tmpdir(), 'gsloth-global-'));
+    homeRoot = mkdtempSync(resolve(tmpdir(), 'gsloth-home-'));
     mockCwd = projectRoot;
-    globalDirMock.dir = globalRoot;
+    homeDirMock.dir = homeRoot;
+    globalRoot = resolve(homeRoot, '.gsloth');
+    mkdirSync(globalRoot, { recursive: true });
 
     mkdirSync(resolve(projectRoot, '.git'), { recursive: true });
 
@@ -78,7 +70,7 @@ describe('CFG-56: -g / --global flag (bypass project config)', () => {
 
   afterEach(() => {
     rmSync(projectRoot, { recursive: true, force: true });
-    rmSync(globalRoot, { recursive: true, force: true });
+    rmSync(homeRoot, { recursive: true, force: true });
   });
 
   const writeProjectConfig = (
@@ -205,6 +197,17 @@ describe('CFG-56: -g / --global flag (bypass project config)', () => {
     expect((error as Error).message).toContain('identity profile "project-only" not found');
   });
 
+  it('names the global profile dir with real path separators when a profile is missing', async () => {
+    const { initConfig } = await import('#src/config/loader.js');
+
+    const error = await initConfig({ global: true, identityProfile: 'ghost' }).catch(
+      (e: unknown) => e
+    );
+    expect((error as Error).message).toContain(
+      `${resolve(globalRoot, '.gsloth-settings', 'ghost')}${sep}`
+    );
+  });
+
   it('throws ConfigDiscoveryError when global config does not exist and global is true', async () => {
     writeProjectConfig({ llm: { type: 'vertexai', model: 'project-model' } });
 
@@ -243,5 +246,113 @@ describe('CFG-56: -g / --global flag (bypass project config)', () => {
 
     expect(await loadConfiguredTui({})).toBe(false);
     expect(await loadConfiguredTui({ global: true })).toBe(true);
+  });
+
+  /**
+   * The global layer is profile-scoped ONLY under `--global`. Without it, `-i <name>` selects a
+   * PROJECT directory and the global layer stays the plain `~/.gsloth/.gsloth.config.*` — which is
+   * what a run loads (`applyGlobalConfigBase` reads it with no profile). Every reader that scoped
+   * the global lookup by the profile alone made `-i` runs diverge from the run they describe.
+   */
+  describe('the global layer stays unscoped for an -i run without --global', () => {
+    it('validateConfig(-i) still validates the plain global layer', async () => {
+      writeProjectProfileConfig('reviewer', { llm: { type: 'vertexai', model: 'reviewer' } });
+      writeGlobalConfig({ llm: { type: 'vertexai' }, streamOutput: 'yes' });
+
+      const { validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({ identityProfile: 'reviewer' });
+      expect(report.layers).toHaveLength(2);
+      expect(report.layers.map((l) => l.sourceLabel)).toContain('.gsloth.config.json (global)');
+      // The run dies on this same file, so the validator must not report the config as valid.
+      expect(report.ok).toBe(false);
+    });
+
+    it('loadConfiguredTui(-i) inherits tui from the plain global config', async () => {
+      writeProjectProfileConfig('reviewer', { llm: { type: 'vertexai', model: 'reviewer' } });
+      writeGlobalConfig({ llm: { type: 'vertexai' }, tui: true });
+
+      const { loadConfiguredTui } = await import('#src/config/loader.js');
+
+      expect(await loadConfiguredTui({ identityProfile: 'reviewer' })).toBe(true);
+    });
+
+    it('hasAnyConfig(-i) sees a plain global config', async () => {
+      writeGlobalConfig({ llm: { type: 'vertexai' } });
+
+      const { hasAnyConfig } = await import('#src/config/loader.js');
+
+      expect(await hasAnyConfig({ identityProfile: 'reviewer' })).toBe(true);
+    });
+  });
+
+  describe("the global layer's extends is walked exactly where a run walks it", () => {
+    it('is not walked when a project config exists', async () => {
+      // With a project config the run underlays the RAW global config (applyGlobalConfigBase) and
+      // never resolves its `extends`, so a base that resolves nowhere cannot fail that run.
+      writeProjectConfig({ llm: { type: 'vertexai', model: 'project-model' } });
+      writeGlobalConfig({ llm: { type: 'vertexai' }, extends: 'nowhere' });
+
+      const { validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({});
+      expect(report.ok).toBe(true);
+    });
+
+    it('is walked when the global config is the only layer', async () => {
+      // No project config: the run loads the global config and DOES resolve its `extends`, so an
+      // unresolvable base is a real failure the validator must report.
+      writeGlobalConfig({ llm: { type: 'vertexai' }, extends: 'nowhere' });
+
+      const { validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({});
+      expect(report.ok).toBe(false);
+      expect(report.layers[0].errorMessage).toContain('nowhere');
+    });
+  });
+
+  /**
+   * The `approvals.rater` existence check runs on the LAYER, so it must resolve the named profile
+   * in that layer's scope. Under `--global` that is `~/.gsloth/.gsloth-settings/` — the same scope
+   * `gth -g config validate` reports on.
+   */
+  describe('approvals.rater resolves in the scope of the run', () => {
+    it('accepts a rater profile that exists globally', async () => {
+      writeGlobalProfileConfig('safety', { llm: { type: 'vertexai', model: 'safety-model' } });
+      writeGlobalConfig({
+        llm: { type: 'vertexai', model: 'global-model' },
+        approvals: { rater: 'safety' },
+      });
+
+      const { initConfig, validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({ global: true });
+      expect(report.ok).toBe(true);
+
+      const resolved = await initConfig({ global: true });
+      expect(resolved.modelDisplayName).toBe('global-model');
+    });
+
+    it('rejects a rater profile that exists only in the project', async () => {
+      writeProjectProfileConfig('safety', { llm: { type: 'vertexai', model: 'project-safety' } });
+      writeGlobalConfig({
+        llm: { type: 'vertexai', model: 'global-model' },
+        approvals: { rater: 'safety' },
+      });
+
+      const { initConfig, validateConfig } = await import('#src/config/loader.js');
+
+      const report = await validateConfig({ global: true });
+      expect(report.ok).toBe(false);
+
+      const error = await initConfig({ global: true }).catch((e: unknown) => e);
+      expect(isConfigDiscoveryError(error)).toBe(true);
+      expect((error as Error).message).toContain('identity profile "safety" not found');
+      // The message must name the directory that was actually searched, not the project one.
+      expect((error as Error).message).toContain(
+        `${resolve(globalRoot, '.gsloth-settings', 'safety')}${sep}`
+      );
+    });
   });
 });

--- a/packages/core/spec/config.globalFlag.spec.ts
+++ b/packages/core/spec/config.globalFlag.spec.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { isConfigDiscoveryError } from '#src/config/configDiscovery.js';
+
+const consoleUtilsMock = {
+  display: vi.fn(),
+  displayError: vi.fn(),
+  displayInfo: vi.fn(),
+  displayWarning: vi.fn(),
+  displaySuccess: vi.fn(),
+  displayDebug: vi.fn(),
+  setConsoleLevel: vi.fn(),
+};
+vi.mock('#src/utils/consoleUtils.js', () => consoleUtilsMock);
+
+let mockProjectDir: string | undefined = undefined;
+let mockCwd: string = '';
+
+vi.mock('#src/utils/systemUtils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('#src/utils/systemUtils.js')>();
+  return {
+    ...actual,
+    getCurrentWorkDir: () => mockCwd,
+    getProjectDir: () => mockProjectDir ?? mockCwd,
+    setProjectDir: (dir: string | undefined) => {
+      mockProjectDir = dir;
+    },
+    isTTY: () => true,
+    isStdoutTTY: () => true,
+  };
+});
+
+// Override getGlobalGslothDir and getGlobalGslothConfigReadPath to a dedicated temp global dir.
+const globalDirMock = {
+  dir: '',
+};
+vi.mock('#src/utils/globalConfigUtils.js', async () => {
+  const actual = await vi.importActual<typeof import('#src/utils/globalConfigUtils.js')>(
+    '#src/utils/globalConfigUtils.js'
+  );
+  return {
+    ...actual,
+    getGlobalGslothDir: () => globalDirMock.dir,
+    getGlobalGslothConfigReadPath: (filename: string, identityProfile?: string) => {
+      const p = identityProfile?.trim();
+      if (p) {
+        return resolve(globalDirMock.dir, '.gsloth-settings', p, filename);
+      }
+      return resolve(globalDirMock.dir, filename);
+    },
+  };
+});
+
+describe('CFG-56: -g / --global flag (bypass project config)', () => {
+  let projectRoot: string;
+  let globalRoot: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectDir = undefined;
+    projectRoot = mkdtempSync(resolve(tmpdir(), 'gsloth-project-'));
+    globalRoot = mkdtempSync(resolve(tmpdir(), 'gsloth-global-'));
+    mockCwd = projectRoot;
+    globalDirMock.dir = globalRoot;
+
+    mkdirSync(resolve(projectRoot, '.git'), { recursive: true });
+
+    vi.doMock('#src/providers/vertexai.js', () => ({
+      processJsonConfig: vi.fn().mockImplementation((llm: Record<string, unknown>) => ({
+        type: 'vertexai',
+        ...llm,
+      })),
+      postProcessJsonConfig: undefined,
+    }));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(globalRoot, { recursive: true, force: true });
+  });
+
+  const writeProjectConfig = (
+    content: Record<string, unknown>,
+    filename = '.gsloth.config.json'
+  ) => {
+    const p = resolve(projectRoot, filename);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  const writeGlobalConfig = (
+    content: Record<string, unknown>,
+    filename = '.gsloth.config.json'
+  ) => {
+    const p = resolve(globalRoot, filename);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  const writeGlobalProfileConfig = (
+    profile: string,
+    content: Record<string, unknown>,
+    filename = '.gsloth.config.json'
+  ) => {
+    const dir = resolve(globalRoot, '.gsloth-settings', profile);
+    mkdirSync(dir, { recursive: true });
+    const p = resolve(dir, filename);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  const writeProjectProfileConfig = (
+    profile: string,
+    content: Record<string, unknown>,
+    filename = '.gsloth.config.json'
+  ) => {
+    const dir = resolve(projectRoot, '.gsloth', '.gsloth-settings', profile);
+    mkdirSync(dir, { recursive: true });
+    const p = resolve(dir, filename);
+    writeFileSync(p, JSON.stringify(content));
+    return p;
+  };
+
+  it('findProjectConfigPath returns undefined and hasProjectConfig returns false when global is active', async () => {
+    writeProjectConfig({ llm: { type: 'vertexai', model: 'project-model' } });
+    const { findProjectConfigPath, hasProjectConfig } = await import('#src/config/loader.js');
+
+    // Without global override: finds project config
+    expect(findProjectConfigPath({})).toBeDefined();
+    expect(hasProjectConfig({})).toBe(true);
+
+    // With global override: bypasses project config
+    expect(findProjectConfigPath({ global: true })).toBeUndefined();
+    expect(hasProjectConfig({ global: true })).toBe(false);
+  });
+
+  it('initConfig({ global: true }) loads only global configuration, ignoring project config', async () => {
+    writeProjectConfig({
+      llm: { type: 'vertexai', model: 'project-model' },
+      prompts: { guidelines: 'PROJECT-GUIDELINES.md' },
+    });
+    writeGlobalConfig({
+      llm: { type: 'vertexai', model: 'global-model' },
+      prompts: { guidelines: 'GLOBAL-GUIDELINES.md' },
+    });
+
+    const { initConfig } = await import('#src/config/loader.js');
+
+    // Default run (no global flag): project config takes precedence
+    const projectResolved = await initConfig({});
+    expect(projectResolved.modelDisplayName).toBe('project-model');
+    expect(projectResolved.prompts?.guidelines).toBe('PROJECT-GUIDELINES.md');
+
+    // With global flag: loads only global config
+    const globalResolved = await initConfig({ global: true });
+    expect(globalResolved.modelDisplayName).toBe('global-model');
+    expect(globalResolved.prompts?.guidelines).toBe('GLOBAL-GUIDELINES.md');
+  });
+
+  it('initConfig({ global: true, identityProfile: "sec" }) resolves profile in ~/.gsloth/.gsloth-settings/sec/', async () => {
+    writeProjectProfileConfig('sec', {
+      llm: { type: 'vertexai', model: 'project-sec-model' },
+    });
+    writeGlobalProfileConfig('sec', {
+      llm: { type: 'vertexai', model: 'global-sec-model' },
+    });
+
+    const { initConfig } = await import('#src/config/loader.js');
+
+    const resolved = await initConfig({ global: true, identityProfile: 'sec' });
+    expect(resolved.modelDisplayName).toBe('global-sec-model');
+  });
+
+  it('resolves extends chain under ~/.gsloth/.gsloth-settings/ when global is active', async () => {
+    writeGlobalProfileConfig('base-profile', {
+      llm: { type: 'vertexai', model: 'global-base-model' },
+      organization: { name: 'GlobalBaseOrg' },
+    });
+    writeGlobalProfileConfig('child-profile', {
+      extends: 'base-profile',
+      organization: { name: 'GlobalChildOrg' },
+    });
+
+    const { initConfig } = await import('#src/config/loader.js');
+
+    const resolved = await initConfig({ global: true, identityProfile: 'child-profile' });
+    expect(resolved.modelDisplayName).toBe('global-base-model');
+    expect(resolved.organization?.name).toBe('GlobalChildOrg');
+  });
+
+  it('throws ConfigDiscoveryError when explicit profile is missing globally', async () => {
+    // Only exists in project, not in global
+    writeProjectProfileConfig('project-only', {
+      llm: { type: 'vertexai', model: 'project-model' },
+    });
+
+    const { initConfig } = await import('#src/config/loader.js');
+
+    const error = await initConfig({ global: true, identityProfile: 'project-only' }).catch(
+      (e: unknown) => e
+    );
+    expect(isConfigDiscoveryError(error)).toBe(true);
+    expect((error as Error).message).toContain('identity profile "project-only" not found');
+  });
+
+  it('throws ConfigDiscoveryError when global config does not exist and global is true', async () => {
+    writeProjectConfig({ llm: { type: 'vertexai', model: 'project-model' } });
+
+    const { initConfig } = await import('#src/config/loader.js');
+
+    const error = await initConfig({ global: true }).catch((e: unknown) => e);
+    expect(isConfigDiscoveryError(error)).toBe(true);
+    expect((error as Error).message).toContain('No configuration file found');
+  });
+
+  it('validateConfig({ global: true }) inspects only the global layer', async () => {
+    writeProjectConfig({ llm: { type: 'vertexai', model: 'project-model' } });
+    writeGlobalConfig({ llm: { type: 'vertexai', model: 'global-model' } });
+
+    const { validateConfig } = await import('#src/config/loader.js');
+
+    // Default validation: validates both project and global layers
+    const reportDefault = await validateConfig({});
+    expect(reportDefault.found).toBe(true);
+    expect(reportDefault.ok).toBe(true);
+    expect(reportDefault.layers).toHaveLength(2);
+
+    // Global-only validation: validates only the global layer
+    const reportGlobal = await validateConfig({ global: true });
+    expect(reportGlobal.found).toBe(true);
+    expect(reportGlobal.ok).toBe(true);
+    expect(reportGlobal.layers).toHaveLength(1);
+    expect(reportGlobal.layers[0].sourceLabel).toBe('.gsloth.config.json (global)');
+  });
+
+  it('loadConfiguredTui({ global: true }) ignores project tui and returns global tui', async () => {
+    writeProjectConfig({ llm: { type: 'vertexai' }, tui: false });
+    writeGlobalConfig({ llm: { type: 'vertexai' }, tui: true });
+
+    const { loadConfiguredTui } = await import('#src/config/loader.js');
+
+    expect(await loadConfiguredTui({})).toBe(false);
+    expect(await loadConfiguredTui({ global: true })).toBe(true);
+  });
+});

--- a/packages/core/spec/config.jsonc.spec.ts
+++ b/packages/core/spec/config.jsonc.spec.ts
@@ -15,7 +15,8 @@ import { resolve } from 'node:path';
 // - the vertexai provider module → initConfig's tryJsonConfig would otherwise build a real LLM;
 // - systemUtils.exit → throws instead of killing the vitest worker if an error path is hit.
 const { getGlobalGslothConfigReadPathMock, exitMock, processJsonConfigMock } = vi.hoisted(() => ({
-  getGlobalGslothConfigReadPathMock: vi.fn<(_filename: string) => string>(),
+  getGlobalGslothConfigReadPathMock:
+    vi.fn<(_filename: string, _identityProfile?: string) => string>(),
   exitMock: vi.fn<(_code?: number) => never>(),
   processJsonConfigMock: vi.fn(),
 }));
@@ -59,8 +60,11 @@ describe('.gsloth.config.jsonc support (GS2-69)', () => {
     root = mkdtempSync(resolve(tmpdir(), 'gsloth-jsonc-'));
     globalDir = resolve(root, '__global__');
     mkdirSync(globalDir, { recursive: true });
-    getGlobalGslothConfigReadPathMock.mockImplementation((filename: string) =>
-      resolve(globalDir, filename)
+    // Redirect the global dir ONLY; the profile-segment rule stays production code, so a
+    // profile-scoped global lookup cannot silently resolve to the unscoped path here.
+    const { resolveGlobalConfigPath } = await import('#src/utils/globalConfigUtils.js');
+    getGlobalGslothConfigReadPathMock.mockImplementation((filename, identityProfile) =>
+      resolveGlobalConfigPath(globalDir, filename, identityProfile)
     );
     exitMock.mockImplementation((code?: number) => {
       throw new Error(`exit(${code}) called`);

--- a/packages/core/spec/config.tui.spec.ts
+++ b/packages/core/spec/config.tui.spec.ts
@@ -14,7 +14,8 @@ import { resolve } from 'node:path';
 // Every path here is built with resolve() rather than a POSIX literal, so the assertions mean the
 // same thing on the Windows CI cell.
 const { getGlobalGslothConfigReadPathMock, exitMock, processJsonConfigMock } = vi.hoisted(() => ({
-  getGlobalGslothConfigReadPathMock: vi.fn<(_filename: string) => string>(),
+  getGlobalGslothConfigReadPathMock:
+    vi.fn<(_filename: string, _identityProfile?: string) => string>(),
   exitMock: vi.fn<(_code?: number) => never>(),
   processJsonConfigMock: vi.fn(),
 }));
@@ -56,8 +57,11 @@ describe('tui config key (CFG-37)', () => {
     mkdirSync(resolve(projectDir, '.git'), { recursive: true });
     process.env.INIT_CWD = projectDir;
 
-    getGlobalGslothConfigReadPathMock.mockImplementation((filename: string) =>
-      resolve(globalDir, filename)
+    // Redirect the global dir ONLY; the profile-segment rule stays production code, so a
+    // profile-scoped global lookup cannot silently resolve to the unscoped path here.
+    const { resolveGlobalConfigPath } = await import('#src/utils/globalConfigUtils.js');
+    getGlobalGslothConfigReadPathMock.mockImplementation((filename, identityProfile) =>
+      resolveGlobalConfigPath(globalDir, filename, identityProfile)
     );
     exitMock.mockImplementation((code?: number) => {
       throw new Error(`exit(${code}) called`);

--- a/packages/core/spec/configValidate.spec.ts
+++ b/packages/core/spec/configValidate.spec.ts
@@ -14,7 +14,8 @@ import { resolve } from 'node:path';
 // globalConfigUtils and triggers the factory during module evaluation, before a plain top-level
 // const would be initialized).
 const { getGlobalGslothConfigReadPathMock, displayWarningMock } = vi.hoisted(() => ({
-  getGlobalGslothConfigReadPathMock: vi.fn<(_filename: string) => string>(),
+  getGlobalGslothConfigReadPathMock:
+    vi.fn<(_filename: string, _identityProfile?: string) => string>(),
   displayWarningMock: vi.fn<(_message: string) => void>(),
 }));
 vi.mock('#src/utils/globalConfigUtils.js', async (importOriginal) => {
@@ -38,7 +39,7 @@ describe('validateConfig (GS2-1 `gth config validate`)', () => {
   let globalDir: string;
   const origInitCwd = process.env.INIT_CWD;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks(); // AGENTS.md — reset first; re-apply the read-path impl below.
     root = mkdtempSync(resolve(tmpdir(), 'gsloth-validate-'));
     // A dedicated, EMPTY global dir per test: `getGlobalGslothConfigReadPath('<name>')` resolves
@@ -46,8 +47,11 @@ describe('validateConfig (GS2-1 `gth config validate`)', () => {
     // single-layer behaviour). Tests opt into a global layer via `global(...)`.
     globalDir = resolve(root, '__global__');
     mkdirSync(globalDir, { recursive: true });
-    getGlobalGslothConfigReadPathMock.mockImplementation((filename: string) =>
-      resolve(globalDir, filename)
+    // Redirect the global dir ONLY; the profile-segment rule stays production code, so a
+    // profile-scoped global lookup cannot silently resolve to the unscoped path here.
+    const { resolveGlobalConfigPath } = await import('#src/utils/globalConfigUtils.js');
+    getGlobalGslothConfigReadPathMock.mockImplementation((filename, identityProfile) =>
+      resolveGlobalConfigPath(globalDir, filename, identityProfile)
     );
   });
 

--- a/packages/core/spec/globalConfigUtils.spec.ts
+++ b/packages/core/spec/globalConfigUtils.spec.ts
@@ -10,8 +10,14 @@ import {
   getGlobalGslothConfigWritePath,
   getGlobalGslothDir,
   getOAuthStoragePath,
+  resolveGlobalConfigPath,
 } from '#src/utils/globalConfigUtils.js';
-import { GSLOTH_AUTH, GSLOTH_DIR, USER_PROJECT_CONFIG_JSON } from '#src/constants.js';
+import {
+  GSLOTH_AUTH,
+  GSLOTH_DIR,
+  GSLOTH_SETTINGS_DIR,
+  USER_PROJECT_CONFIG_JSON,
+} from '#src/constants.js';
 
 vi.mock('node:fs');
 vi.mock('node:os');
@@ -64,6 +70,36 @@ describe('globalConfigUtils', () => {
     it('should not create the directory (read-only resolver)', () => {
       getGlobalGslothConfigReadPath(USER_PROJECT_CONFIG_JSON);
       expect(mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it('should resolve under .gsloth-settings/<profile>/ when an identity profile is named', () => {
+      const result = getGlobalGslothConfigReadPath(USER_PROJECT_CONFIG_JSON, 'sec');
+      expect(result).toBe(
+        resolve(mockHomeDir, GSLOTH_DIR, GSLOTH_SETTINGS_DIR, 'sec', USER_PROJECT_CONFIG_JSON)
+      );
+    });
+
+    it('should treat a blank identity profile as no profile', () => {
+      expect(getGlobalGslothConfigReadPath(USER_PROJECT_CONFIG_JSON, '   ')).toBe(
+        resolve(mockHomeDir, GSLOTH_DIR, USER_PROJECT_CONFIG_JSON)
+      );
+    });
+
+    it('should trim a padded identity profile name', () => {
+      expect(getGlobalGslothConfigReadPath(USER_PROJECT_CONFIG_JSON, ' sec ')).toBe(
+        resolve(mockHomeDir, GSLOTH_DIR, GSLOTH_SETTINGS_DIR, 'sec', USER_PROJECT_CONFIG_JSON)
+      );
+    });
+  });
+
+  describe('resolveGlobalConfigPath', () => {
+    it('should compose against an arbitrary global dir, with and without a profile', () => {
+      expect(resolveGlobalConfigPath('/elsewhere', USER_PROJECT_CONFIG_JSON)).toBe(
+        resolve('/elsewhere', USER_PROJECT_CONFIG_JSON)
+      );
+      expect(resolveGlobalConfigPath('/elsewhere', USER_PROJECT_CONFIG_JSON, 'sec')).toBe(
+        resolve('/elsewhere', GSLOTH_SETTINGS_DIR, 'sec', USER_PROJECT_CONFIG_JSON)
+      );
     });
   });
 

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1833,14 +1833,10 @@ export async function validateConfig(
       ...validateRawGthConfig(globalRaw.raw, validationOptions),
     };
 
-    if (
-      commandLineConfigOverrides.global &&
-      layer.ok &&
-      typeof globalRaw.raw.extends === 'string'
-    ) {
+    if (layer.ok && typeof globalRaw.raw.extends === 'string') {
       try {
         await composeExtends(globalRaw.raw, commandLineConfigOverrides.identityProfile, {
-          globalOnly: true,
+          globalOnly: commandLineConfigOverrides.global,
         });
       } catch (e) {
         if (e instanceof ConfigExtendsError || isConfigDiscoveryError(e)) {

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -52,7 +52,7 @@ import { resolveUseMouse } from '#src/config/mouse.js';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
 import { DEFAULT_CONFIG } from '#src/config/defaults.js';
 import type {
   CommandLineConfigOverrides,
@@ -61,6 +61,44 @@ import type {
   LLMConfig,
   RawGthConfig,
 } from '#src/config/types.js';
+
+/**
+ * CFG-56 — where a profile NAMED FROM INSIDE a config layer (`extends`, `approvals.rater.profile`)
+ * is allowed to resolve. `globalOnly` restricts the lookup to
+ * `~/.gsloth/.gsloth-settings/<name>/`, which is what a `--global` run must do: resolving such a
+ * name up-tree would readmit the project config that `--global` exists to bypass. Absent/false
+ * keeps the ordinary up-tree project walk.
+ *
+ * Spelled inline (not by this name) in the module's EXPORTED signatures, so the package's public
+ * type surface gains no name for what is an internal scoping detail.
+ */
+interface ProfileScopeOptions {
+  globalOnly?: boolean;
+}
+
+/**
+ * CFG-56 — the identity profile the GLOBAL layer is read under, which is NOT simply
+ * `identityProfile`: only a `--global` run relocates the global layer into
+ * `~/.gsloth/.gsloth-settings/<name>/`. Without `--global`, `-i <name>` selects a PROJECT-layer
+ * directory and the global layer stays the plain `~/.gsloth/.gsloth.config.*` — which is exactly
+ * what a run does ({@link applyGlobalConfigBase} reads it with no profile). Every reader of the
+ * global layer goes through this so the diagnostics (`gth config validate`, the `tui` reader,
+ * first-run detection) cannot scope it differently from the run.
+ */
+function globalLayerProfile(
+  commandLineConfigOverrides: CommandLineConfigOverrides
+): string | undefined {
+  return commandLineConfigOverrides.global ? commandLineConfigOverrides.identityProfile : undefined;
+}
+
+/**
+ * The `~/.gsloth/.gsloth-settings/<profile>/` directory as shown to a user in an error message or
+ * a layer label. Composed with the path helpers, so a Windows home dir does not surface as a
+ * mixed-separator `C:\Users\x\.gsloth/.gsloth-settings/sec/`.
+ */
+function globalProfileDirLabel(profile: string): string {
+  return `${resolve(getGlobalGslothDir(), GSLOTH_SETTINGS_DIR, profile)}${sep}`;
+}
 
 /**
  * Validate (and normalize) a freshly loaded raw config layer (global or project)
@@ -97,9 +135,14 @@ import type {
  *
  * @param raw The freshly loaded config layer (read-only here).
  * @param sourceLabel Human-readable source name for messages (e.g. the filename).
+ * @param options Profile-resolution scope for this layer — see {@link ProfileScopeOptions}.
  * @throws ConfigDiscoveryError when the layer carries a hard configuration error.
  */
-function validateRawConfigLayer<T extends Record<string, unknown>>(raw: T, sourceLabel: string): T {
+function validateRawConfigLayer<T extends Record<string, unknown>>(
+  raw: T,
+  sourceLabel: string,
+  options?: ProfileScopeOptions
+): T {
   // Only an object config can carry deprecated/unknown keys; a null/array/primitive config skips
   // the scans (they'd throw a raw TypeError) and falls to safeParse, which emits a clean
   // "expected object" error + exit — never a coercion to {} (which would wrongly pass).
@@ -146,12 +189,21 @@ function validateRawConfigLayer<T extends Record<string, unknown>>(raw: T, sourc
   // resolve to a real profile config is a hard error, never a silent fallback to the main model.
   // Checked HERE rather than in the zod schema on purpose — resolution needs the filesystem and
   // `schema.ts` must stay pure (it also feeds `z.toJSONSchema`).
+  //
+  // CFG-56 — the resolution SCOPE travels with the layer. Under `--global` a rater profile must
+  // resolve under `~/.gsloth/.gsloth-settings/`, exactly as `validateConfig`'s `resolveProfile`
+  // hook resolves it: an unscoped check here would accept a project profile in a run whose whole
+  // purpose is to bypass project config, and reject a global one that `gth -g config validate`
+  // just called valid.
   if (isRecordConfig(raw)) {
     for (const ref of findApprovalsRaterProfiles(raw)) {
-      if (!resolveIdentityProfileConfigPath(ref.profile)) {
+      if (!resolveIdentityProfileConfigPath(ref.profile, options)) {
         throw new ConfigDiscoveryError(
           `Invalid configuration in ${sourceLabel}:\n` +
-            `  - ${ref.path}: ${unresolvedRaterProfileMessage(ref)}`,
+            `  - ${ref.path}: ${unresolvedRaterProfileMessage(
+              ref,
+              options?.globalOnly ? globalProfileDirLabel(ref.profile) : undefined
+            )}`,
           { sourceLabel, identityProfile: ref.profile }
         );
       }
@@ -328,6 +380,8 @@ export function findProjectConfigPath(
  * as "no profile" → `undefined`.
  *
  * @param identityProfile The explicitly-requested identity profile name.
+ * @param options CFG-56 — `globalOnly` searches `~/.gsloth/.gsloth-settings/<name>/` INSTEAD of
+ * the up-tree project walk, for a `--global` run.
  * @returns The resolved profile config path, or `undefined` when the profile has no config.
  */
 export function resolveIdentityProfileConfigPath(
@@ -390,7 +444,7 @@ function findUnresolvedExplicitProfile(
 /** The message both paths report for {@link findUnresolvedExplicitProfile}'s failure. */
 function identityProfileNotFoundMessage(profile: string, isGlobal = false): string {
   const base = isGlobal
-    ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${profile}/`
+    ? globalProfileDirLabel(profile)
     : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${profile}/`;
   return (
     `identity profile "${profile}" not found: no config file in ` +
@@ -414,11 +468,17 @@ function identityProfileNotFoundMessage(profile: string, isGlobal = false): stri
  * NOTE: secrets (API keys) may live in this file; this function must never log its
  * contents. Only non-sensitive diagnostics (the resolved path / parse failure) are emitted.
  *
+ * @param options CFG-56 — `identityProfile` relocates the lookup to
+ * `~/.gsloth/.gsloth-settings/<name>/` and `globalOnly` scopes the profile names this layer refers
+ * to. Both are set ONLY for a `--global` run; see {@link globalLayerProfile}.
  * @returns The raw global config object, or `undefined` when no global config exists.
  */
-export async function loadGlobalRawConfig(
-  identityProfile?: string
-): Promise<Partial<RawGthConfig> | undefined> {
+export async function loadGlobalRawConfig(options?: {
+  identityProfile?: string;
+  globalOnly?: boolean;
+}): Promise<Partial<RawGthConfig> | undefined> {
+  const identityProfile = options?.identityProfile;
+  const scope: ProfileScopeOptions = { globalOnly: options?.globalOnly };
   // JSON/JSONC first (the must-have formats; `.json` wins when both exist — GS2-69).
   for (const filename of JSON_CONFIG_FILENAMES) {
     const jsonPath = getGlobalGslothConfigReadPath(filename, identityProfile);
@@ -428,7 +488,7 @@ export async function loadGlobalRawConfig(
         : `${filename} (global)`;
       try {
         const parsed = parseJsonc(readFileSync(jsonPath, 'utf8'), label) as Record<string, unknown>;
-        return validateRawConfigLayer(parsed, label) as Partial<RawGthConfig>;
+        return validateRawConfigLayer(parsed, label, scope) as Partial<RawGthConfig>;
       } catch (e) {
         // CFG-36 — this catch exists to treat an UNREADABLE global as absent. A global that read
         // fine and is MALFORMED is a hard configuration error (it used to `exit(1)` from inside
@@ -456,7 +516,8 @@ export async function loadGlobalRawConfig(
         const configured = await imported.configure();
         return validateRawConfigLayer(
           configured as Record<string, unknown>,
-          label
+          label,
+          scope
         ) as Partial<RawGthConfig>;
       } catch (e) {
         // CFG-36 — see the JSON branch above: a malformed global is a hard error, not an absent one.
@@ -586,7 +647,7 @@ export async function resolveConfigExtends(
 async function composeExtends(
   rawConfig: Record<string, unknown>,
   profileLabel: string | undefined,
-  options?: { globalOnly?: boolean }
+  options?: ProfileScopeOptions
 ): Promise<Record<string, unknown>> {
   const seed = profileLabel?.trim();
   return resolveExtendsChain(rawConfig, seed ? [seed] : [], options);
@@ -604,7 +665,7 @@ async function composeExtends(
 async function resolveExtendsChain(
   rawConfig: Record<string, unknown>,
   chain: string[],
-  options?: { globalOnly?: boolean }
+  options?: ProfileScopeOptions
 ): Promise<Record<string, unknown>> {
   const baseName = typeof rawConfig.extends === 'string' ? rawConfig.extends.trim() : undefined;
   if (!baseName) {
@@ -633,7 +694,7 @@ async function resolveExtendsChain(
   if (!basePath) {
     const from = chain.length > 0 ? ` (referenced from "${chain[chain.length - 1]}")` : '';
     const baseDir = options?.globalOnly
-      ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${baseName}/`
+      ? globalProfileDirLabel(baseName)
       : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${baseName}/`;
     throw new ConfigExtendsError(
       `Profile "${baseName}" referenced by "extends"${from} was not found: no config file in ` +
@@ -651,7 +712,7 @@ async function resolveExtendsChain(
 
   // Validate the base layer exactly as the project layer is validated (deprecated-shape reject,
   // unknown-key warn, type-mismatch fail) so a broken base surfaces loudly rather than silently.
-  const validatedBase = validateRawConfigLayer(baseRaw, `${baseName} (extends base)`);
+  const validatedBase = validateRawConfigLayer(baseRaw, `${baseName} (extends base)`, options);
 
   // Resolve the base's OWN extends first (base-of-base first), THEN merge this profile's delta on
   // top via the existing GS2-1 deep-merge (child = source, so it wins; additive-array fields at the
@@ -700,7 +761,12 @@ export async function hasAnyConfig(
   if (hasProjectConfig(commandLineConfigOverrides)) {
     return true;
   }
-  return (await loadGlobalRawConfig(commandLineConfigOverrides.identityProfile)) !== undefined;
+  return (
+    (await loadGlobalRawConfig({
+      identityProfile: globalLayerProfile(commandLineConfigOverrides),
+      globalOnly: commandLineConfigOverrides.global,
+    })) !== undefined
+  );
 }
 
 /**
@@ -740,7 +806,7 @@ export async function loadConfiguredTui(
     return projectTui;
   }
   const globalRaw = await loadGlobalRawConfigUnvalidated(
-    commandLineConfigOverrides.identityProfile
+    globalLayerProfile(commandLineConfigOverrides)
   );
   const globalTui = globalRaw?.raw.tui;
   return typeof globalTui === 'boolean' ? globalTui : undefined;
@@ -872,13 +938,16 @@ export async function initConfig(
     // consulted at all (see above), because gating it on `!discovered` missed the case where a
     // plain project config exists. A run with no profile reaches the global fallback below exactly
     // as before.
-    const globalRawConfig = await loadGlobalRawConfig(commandLineConfigOverrides.identityProfile);
+    const globalRawConfig = await loadGlobalRawConfig({
+      identityProfile: globalLayerProfile(commandLineConfigOverrides),
+      globalOnly: commandLineConfigOverrides.global,
+    });
     if (globalRawConfig) {
       let resolvedRawConfig = globalRawConfig;
       if (typeof resolvedRawConfig.extends === 'string') {
         resolvedRawConfig = (await resolveConfigExtends(
           resolvedRawConfig as Record<string, unknown>,
-          commandLineConfigOverrides.identityProfile,
+          globalLayerProfile(commandLineConfigOverrides),
           { globalOnly: commandLineConfigOverrides.global }
         )) as Partial<RawGthConfig>;
       }
@@ -894,8 +963,9 @@ export async function initConfig(
       // and unusable", the same class CFG-36 converted: raise it, let the caller choose the exit
       // code. The message is the one this branch has always printed, so the CLI's top-level guard
       // reproduces the previous output exactly.
-      const sourceLabel = commandLineConfigOverrides.identityProfile
-        ? `${GSLOTH_SETTINGS_DIR}/${commandLineConfigOverrides.identityProfile}/${USER_PROJECT_CONFIG_JSON} (global)`
+      const globalProfile = globalLayerProfile(commandLineConfigOverrides);
+      const sourceLabel = globalProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${globalProfile}/${USER_PROJECT_CONFIG_JSON} (global)`
         : `${USER_PROJECT_CONFIG_JSON} (global)`;
       throw new ConfigDiscoveryError(
         'Global configuration found but it is not in valid format. Should at least define llm.type',
@@ -1736,20 +1806,29 @@ export interface ConfigValidationReport {
  * GS2-73 — for the PROJECT layer it also walks the GS2-41 profile `extends` chain (via the SAME
  * {@link composeExtends}/{@link resolveExtendsChain} the run path uses), so a cycle or a missing
  * base — which fail a real run — is reported here as a not-ok layer instead of passing OK and only
- * failing at run time. The GLOBAL layer is NOT walked, mirroring the run (`resolveConfigExtends`
- * runs on the project/profile layer only).
+ * failing at run time. The GLOBAL layer is walked on exactly the branch a run walks it: when NO
+ * project layer was discovered, so the global config is what `initConfig` loads and resolves
+ * `extends` on. With a project layer present the run underlays the raw global config
+ * ({@link applyGlobalConfigBase}) and never resolves its `extends`, so neither does this.
  */
 export async function validateConfig(
   commandLineConfigOverrides: CommandLineConfigOverrides
 ): Promise<ConfigValidationReport> {
   const layers: ConfigLayerValidationReport[] = [];
 
-  const validationOptions = {
+  // CFG-26 — the fs-backed `approvals.rater` hook, so this validator enforces the SAME existence
+  // rule the loader hard-fails on (`schema.ts` stays pure; the filesystem knowledge lives here).
+  // CFG-56 — built PER LAYER, because the run resolves a rater profile in the scope of the layer
+  // that named it: the project layer walks up-tree, and the global layer walks
+  // `~/.gsloth/.gsloth-settings/` only under `--global`. One shared hook would answer for the
+  // wrong scope on one of the two layers, which is precisely the validate-vs-run split this
+  // function exists to close.
+  const rawConfigValidationOptions = (scope: ProfileScopeOptions) => ({
     resolveProfile: (profile: string): boolean =>
-      resolveIdentityProfileConfigPath(profile, {
-        globalOnly: commandLineConfigOverrides.global,
-      }) !== undefined,
-  };
+      resolveIdentityProfileConfigPath(profile, scope) !== undefined,
+    describeProfileDir: (profile: string): string | undefined =>
+      scope.globalOnly ? globalProfileDirLabel(profile) : undefined,
+  });
 
   // CFG-36 — mirror the run's STRICT named-profile rule before anything is read. `initConfig`
   // refuses outright when an explicitly-named profile has no config of its own, so a validator that
@@ -1761,7 +1840,7 @@ export async function validateConfig(
   const unresolvedProfile = findUnresolvedExplicitProfile(commandLineConfigOverrides);
   if (unresolvedProfile) {
     const sourceLabel = commandLineConfigOverrides.global
-      ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${unresolvedProfile}/`
+      ? globalProfileDirLabel(unresolvedProfile)
       : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${unresolvedProfile}/`;
     return {
       // `found: true` so the caller renders THIS message. `found: false` means "nothing to
@@ -1790,7 +1869,7 @@ export async function validateConfig(
     const raw = await readRawConfigAtPath(discovered.path);
     const layer: ConfigLayerValidationReport = {
       sourceLabel: discovered.path,
-      ...validateRawGthConfig(raw, validationOptions),
+      ...validateRawGthConfig(raw, rawConfigValidationOptions({})),
     };
 
     // GS2-73 — mirror the run's `extends` resolution. GS2-41's `resolveConfigExtends` walks the
@@ -1825,19 +1904,27 @@ export async function validateConfig(
   // loadGlobalRawConfig in the no-project path), so the diagnostic must validate it too — this is
   // the layer the previous single-layer validateConfig skipped whenever a project config existed.
   const globalRaw = await loadGlobalRawConfigUnvalidated(
-    commandLineConfigOverrides.identityProfile
+    globalLayerProfile(commandLineConfigOverrides)
   );
   if (globalRaw) {
+    const globalScope: ProfileScopeOptions = { globalOnly: commandLineConfigOverrides.global };
     const layer: ConfigLayerValidationReport = {
       sourceLabel: globalRaw.label,
-      ...validateRawGthConfig(globalRaw.raw, validationOptions),
+      ...validateRawGthConfig(globalRaw.raw, rawConfigValidationOptions(globalScope)),
     };
 
-    if (layer.ok && typeof globalRaw.raw.extends === 'string') {
+    // The global layer's `extends` is walked ONLY when there is no project layer, because that is
+    // the only case in which a run walks it: `initConfig`'s no-project branch resolves `extends` on
+    // the global config, while `applyGlobalConfigBase` (the branch taken whenever a project config
+    // exists) deep-merges the raw global config WITHOUT resolving it. Walking it unconditionally
+    // reported a missing base that the run it mirrors never looks for.
+    if (!discovered && layer.ok && typeof globalRaw.raw.extends === 'string') {
       try {
-        await composeExtends(globalRaw.raw, commandLineConfigOverrides.identityProfile, {
-          globalOnly: commandLineConfigOverrides.global,
-        });
+        await composeExtends(
+          globalRaw.raw,
+          globalLayerProfile(commandLineConfigOverrides),
+          globalScope
+        );
       } catch (e) {
         if (e instanceof ConfigExtendsError || isConfigDiscoveryError(e)) {
           layer.ok = false;

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -38,7 +38,7 @@ import { parseJsonc } from '#src/config/jsonc.js';
 import { isMissingProviderKeyError, MissingProviderKeyError } from '#src/config/providerKeys.js';
 import { ConfigDiscoveryError, isConfigDiscoveryError } from '#src/config/configDiscovery.js';
 import { getGslothConfigReadPath, importExternalFile } from '#src/utils/fileUtils.js';
-import { getGlobalGslothConfigReadPath } from '#src/utils/globalConfigUtils.js';
+import { getGlobalGslothConfigReadPath, getGlobalGslothDir } from '#src/utils/globalConfigUtils.js';
 import {
   env,
   getCurrentWorkDir,
@@ -279,6 +279,9 @@ function* walkConfigSearchDirs(): Generator<string> {
 export function findProjectConfigPath(
   commandLineConfigOverrides: CommandLineConfigOverrides
 ): { dir: string; path: string } | undefined {
+  if (commandLineConfigOverrides.global) {
+    return undefined;
+  }
   if (commandLineConfigOverrides.customConfigPath) {
     return existsSync(commandLineConfigOverrides.customConfigPath)
       ? {
@@ -305,16 +308,6 @@ export function findProjectConfigPath(
 }
 
 /**
- * CFG-26 — the read-side validator's fs-backed hook, so `gth config validate`
- * ({@link collectConfigValidationLayers}) enforces the SAME `approvals.rater` existence
- * rule the loader hard-exits on. `schema.ts` stays pure; the filesystem knowledge lives here.
- */
-const RAW_CONFIG_VALIDATION_OPTIONS = {
-  resolveProfile: (profile: string): boolean =>
-    resolveIdentityProfileConfigPath(profile) !== undefined,
-};
-
-/**
  * STRICT existence check for an EXPLICITLY-named identity profile: does
  * `.gsloth/.gsloth-settings/<identityProfile>/<config>` resolve to a real config file anywhere in
  * the same up-tree search {@link findProjectConfigPath} walks? Returns the resolved profile config
@@ -337,9 +330,23 @@ const RAW_CONFIG_VALIDATION_OPTIONS = {
  * @param identityProfile The explicitly-requested identity profile name.
  * @returns The resolved profile config path, or `undefined` when the profile has no config.
  */
-export function resolveIdentityProfileConfigPath(identityProfile: string): string | undefined {
+export function resolveIdentityProfileConfigPath(
+  identityProfile: string,
+  options?: { globalOnly?: boolean }
+): string | undefined {
   const profile = identityProfile?.trim();
   if (!profile) {
+    return undefined;
+  }
+  if (options?.globalOnly) {
+    const globalDir = getGlobalGslothDir();
+    const profileDir = resolve(globalDir, GSLOTH_SETTINGS_DIR, profile);
+    for (const filename of PROJECT_CONFIG_FORMATS) {
+      const candidate = resolve(profileDir, filename);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
     return undefined;
   }
   for (const dir of walkConfigSearchDirs()) {
@@ -373,14 +380,21 @@ function findUnresolvedExplicitProfile(
   if (!profile || commandLineConfigOverrides.customConfigPath) {
     return undefined;
   }
-  return resolveIdentityProfileConfigPath(profile) ? undefined : profile;
+  return resolveIdentityProfileConfigPath(profile, {
+    globalOnly: commandLineConfigOverrides.global,
+  })
+    ? undefined
+    : profile;
 }
 
 /** The message both paths report for {@link findUnresolvedExplicitProfile}'s failure. */
-function identityProfileNotFoundMessage(profile: string): string {
+function identityProfileNotFoundMessage(profile: string, isGlobal = false): string {
+  const base = isGlobal
+    ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${profile}/`
+    : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${profile}/`;
   return (
     `identity profile "${profile}" not found: no config file in ` +
-    `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${profile}/ ` +
+    `${base} ` +
     `(checked ${PROJECT_CONFIG_FORMATS.join(', ')})`
   );
 }
@@ -402,17 +416,19 @@ function identityProfileNotFoundMessage(profile: string): string {
  *
  * @returns The raw global config object, or `undefined` when no global config exists.
  */
-export async function loadGlobalRawConfig(): Promise<Partial<RawGthConfig> | undefined> {
+export async function loadGlobalRawConfig(
+  identityProfile?: string
+): Promise<Partial<RawGthConfig> | undefined> {
   // JSON/JSONC first (the must-have formats; `.json` wins when both exist — GS2-69).
   for (const filename of JSON_CONFIG_FILENAMES) {
-    const jsonPath = getGlobalGslothConfigReadPath(filename);
+    const jsonPath = getGlobalGslothConfigReadPath(filename, identityProfile);
     if (existsSync(jsonPath)) {
+      const label = identityProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${identityProfile}/${filename} (global)`
+        : `${filename} (global)`;
       try {
-        const parsed = parseJsonc(readFileSync(jsonPath, 'utf8'), `${filename} (global)`) as Record<
-          string,
-          unknown
-        >;
-        return validateRawConfigLayer(parsed, `${filename} (global)`) as Partial<RawGthConfig>;
+        const parsed = parseJsonc(readFileSync(jsonPath, 'utf8'), label) as Record<string, unknown>;
+        return validateRawConfigLayer(parsed, label) as Partial<RawGthConfig>;
       } catch (e) {
         // CFG-36 — this catch exists to treat an UNREADABLE global as absent. A global that read
         // fine and is MALFORMED is a hard configuration error (it used to `exit(1)` from inside
@@ -430,14 +446,17 @@ export async function loadGlobalRawConfig(): Promise<Partial<RawGthConfig> | und
 
   // Then JS / MJS variants (dynamic import of a `configure()` module).
   for (const filename of [USER_PROJECT_CONFIG_JS, USER_PROJECT_CONFIG_MJS]) {
-    const modulePath = getGlobalGslothConfigReadPath(filename);
+    const modulePath = getGlobalGslothConfigReadPath(filename, identityProfile);
     if (existsSync(modulePath)) {
+      const label = identityProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${identityProfile}/${filename} (global)`
+        : `${filename} (global)`;
       try {
         const imported = await importExternalFile(modulePath);
         const configured = await imported.configure();
         return validateRawConfigLayer(
           configured as Record<string, unknown>,
-          `${filename} (global)`
+          label
         ) as Partial<RawGthConfig>;
       } catch (e) {
         // CFG-36 — see the JSON branch above: a malformed global is a hard error, not an absent one.
@@ -523,10 +542,11 @@ class ConfigExtendsError extends Error {}
  */
 export async function resolveConfigExtends(
   rawConfig: Record<string, unknown>,
-  profileLabel: string | undefined
+  profileLabel: string | undefined,
+  options?: { globalOnly?: boolean }
 ): Promise<Record<string, unknown>> {
   try {
-    return await composeExtends(rawConfig, profileLabel);
+    return await composeExtends(rawConfig, profileLabel, options);
   } catch (e) {
     // GS2-73 — the traversal RAISES a {@link ConfigExtendsError} rather than exiting inline, so the
     // read side ({@link validateConfig}) can report the same failure without terminating.
@@ -565,10 +585,11 @@ export async function resolveConfigExtends(
  */
 async function composeExtends(
   rawConfig: Record<string, unknown>,
-  profileLabel: string | undefined
+  profileLabel: string | undefined,
+  options?: { globalOnly?: boolean }
 ): Promise<Record<string, unknown>> {
   const seed = profileLabel?.trim();
-  return resolveExtendsChain(rawConfig, seed ? [seed] : []);
+  return resolveExtendsChain(rawConfig, seed ? [seed] : [], options);
 }
 
 /**
@@ -582,7 +603,8 @@ async function composeExtends(
  */
 async function resolveExtendsChain(
   rawConfig: Record<string, unknown>,
-  chain: string[]
+  chain: string[],
+  options?: { globalOnly?: boolean }
 ): Promise<Record<string, unknown>> {
   const baseName = typeof rawConfig.extends === 'string' ? rawConfig.extends.trim() : undefined;
   if (!baseName) {
@@ -607,12 +629,15 @@ async function resolveExtendsChain(
     );
   }
 
-  const basePath = resolveIdentityProfileConfigPath(baseName);
+  const basePath = resolveIdentityProfileConfigPath(baseName, options);
   if (!basePath) {
     const from = chain.length > 0 ? ` (referenced from "${chain[chain.length - 1]}")` : '';
+    const baseDir = options?.globalOnly
+      ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${baseName}/`
+      : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${baseName}/`;
     throw new ConfigExtendsError(
       `Profile "${baseName}" referenced by "extends"${from} was not found: no config file in ` +
-        `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${baseName}/ (checked ${PROJECT_CONFIG_FORMATS.join(', ')}).`
+        `${baseDir} (checked ${PROJECT_CONFIG_FORMATS.join(', ')}).`
     );
   }
 
@@ -631,7 +656,7 @@ async function resolveExtendsChain(
   // Resolve the base's OWN extends first (base-of-base first), THEN merge this profile's delta on
   // top via the existing GS2-1 deep-merge (child = source, so it wins; additive-array fields at the
   // config root accumulate).
-  const resolvedBase = await resolveExtendsChain(validatedBase, [...chain, baseName]);
+  const resolvedBase = await resolveExtendsChain(validatedBase, [...chain, baseName], options);
 
   // Consume `extends` so it never leaks into the composed output, then merge child over base.
   const childDelta: Record<string, unknown> = { ...rawConfig };
@@ -675,7 +700,7 @@ export async function hasAnyConfig(
   if (hasProjectConfig(commandLineConfigOverrides)) {
     return true;
   }
-  return (await loadGlobalRawConfig()) !== undefined;
+  return (await loadGlobalRawConfig(commandLineConfigOverrides.identityProfile)) !== undefined;
 }
 
 /**
@@ -714,7 +739,9 @@ export async function loadConfiguredTui(
   if (projectTui !== undefined) {
     return projectTui;
   }
-  const globalRaw = await loadGlobalRawConfigUnvalidated();
+  const globalRaw = await loadGlobalRawConfigUnvalidated(
+    commandLineConfigOverrides.identityProfile
+  );
   const globalTui = globalRaw?.raw.tui;
   return typeof globalTui === 'boolean' ? globalTui : undefined;
 }
@@ -805,9 +832,12 @@ export async function initConfig(
   // validator can never green-light a profile a run refuses (GS2-29).
   const explicitProfile = findUnresolvedExplicitProfile(commandLineConfigOverrides);
   if (explicitProfile) {
-    throw new ConfigDiscoveryError(identityProfileNotFoundMessage(explicitProfile), {
-      identityProfile: explicitProfile,
-    });
+    throw new ConfigDiscoveryError(
+      identityProfileNotFoundMessage(explicitProfile, commandLineConfigOverrides.global),
+      {
+        identityProfile: explicitProfile,
+      }
+    );
   }
 
   const baseDir = discovered?.dir ?? getCurrentWorkDir();
@@ -842,23 +872,39 @@ export async function initConfig(
     // consulted at all (see above), because gating it on `!discovered` missed the case where a
     // plain project config exists. A run with no profile reaches the global fallback below exactly
     // as before.
-    const globalRawConfig = await loadGlobalRawConfig();
+    const globalRawConfig = await loadGlobalRawConfig(commandLineConfigOverrides.identityProfile);
     if (globalRawConfig) {
+      let resolvedRawConfig = globalRawConfig;
+      if (typeof resolvedRawConfig.extends === 'string') {
+        resolvedRawConfig = (await resolveConfigExtends(
+          resolvedRawConfig as Record<string, unknown>,
+          commandLineConfigOverrides.identityProfile,
+          { globalOnly: commandLineConfigOverrides.global }
+        )) as Partial<RawGthConfig>;
+      }
       if (
-        globalRawConfig.llm &&
-        typeof globalRawConfig.llm === 'object' &&
-        'type' in globalRawConfig.llm
+        resolvedRawConfig.llm &&
+        typeof resolvedRawConfig.llm === 'object' &&
+        'type' in resolvedRawConfig.llm
       ) {
         // Route the global config through the same path the project JSON uses.
-        return await tryJsonConfig(globalRawConfig as RawGthConfig, commandLineConfigOverrides);
+        return await tryJsonConfig(resolvedRawConfig as RawGthConfig, commandLineConfigOverrides);
       }
       // CFG-47 — a global config that read fine and does not define `llm.type` is "config present
       // and unusable", the same class CFG-36 converted: raise it, let the caller choose the exit
       // code. The message is the one this branch has always printed, so the CLI's top-level guard
       // reproduces the previous output exactly.
+      const sourceLabel = commandLineConfigOverrides.identityProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${commandLineConfigOverrides.identityProfile}/${USER_PROJECT_CONFIG_JSON} (global)`
+        : `${USER_PROJECT_CONFIG_JSON} (global)`;
       throw new ConfigDiscoveryError(
         'Global configuration found but it is not in valid format. Should at least define llm.type',
-        { sourceLabel: `${USER_PROJECT_CONFIG_JSON} (global)` }
+        { sourceLabel }
+      );
+    }
+    if (commandLineConfigOverrides.global) {
+      throw new ConfigDiscoveryError(
+        'No configuration file found. Please create one in ~/.gsloth.'
       );
     }
   }
@@ -1592,13 +1638,15 @@ async function readRawConfigAtPath(path: string): Promise<Record<string, unknown
  * keeps `gth config validate` a faithful mirror of the run rather than staying silent about a
  * problem the run flags.
  */
-async function loadGlobalRawConfigUnvalidated(): Promise<
-  { raw: Record<string, unknown>; label: string } | undefined
-> {
+async function loadGlobalRawConfigUnvalidated(
+  identityProfile?: string
+): Promise<{ raw: Record<string, unknown>; label: string } | undefined> {
   for (const filename of JSON_CONFIG_FILENAMES) {
-    const jsonPath = getGlobalGslothConfigReadPath(filename);
+    const jsonPath = getGlobalGslothConfigReadPath(filename, identityProfile);
     if (existsSync(jsonPath)) {
-      const label = `${filename} (global)`;
+      const label = identityProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${identityProfile}/${filename} (global)`
+        : `${filename} (global)`;
       try {
         return {
           raw: parseJsonc(readFileSync(jsonPath, 'utf8'), label) as Record<string, unknown>,
@@ -1612,13 +1660,16 @@ async function loadGlobalRawConfigUnvalidated(): Promise<
     }
   }
   for (const filename of [USER_PROJECT_CONFIG_JS, USER_PROJECT_CONFIG_MJS]) {
-    const modulePath = getGlobalGslothConfigReadPath(filename);
+    const modulePath = getGlobalGslothConfigReadPath(filename, identityProfile);
     if (existsSync(modulePath)) {
+      const label = identityProfile
+        ? `${GSLOTH_SETTINGS_DIR}/${identityProfile}/${filename} (global)`
+        : `${filename} (global)`;
       try {
         const imported = await importExternalFile(modulePath);
         return {
           raw: (await imported.configure()) as Record<string, unknown>,
-          label: `${filename} (global)`,
+          label,
         };
       } catch (e) {
         displayDebug(e instanceof Error ? e : String(e));
@@ -1693,6 +1744,13 @@ export async function validateConfig(
 ): Promise<ConfigValidationReport> {
   const layers: ConfigLayerValidationReport[] = [];
 
+  const validationOptions = {
+    resolveProfile: (profile: string): boolean =>
+      resolveIdentityProfileConfigPath(profile, {
+        globalOnly: commandLineConfigOverrides.global,
+      }) !== undefined,
+  };
+
   // CFG-36 — mirror the run's STRICT named-profile rule before anything is read. `initConfig`
   // refuses outright when an explicitly-named profile has no config of its own, so a validator that
   // walked on would report OK for a config the run rejects — and it would do so in the ordinary
@@ -1702,6 +1760,9 @@ export async function validateConfig(
   // COLLECTS and never terminates; returned immediately because a run gets no further either.
   const unresolvedProfile = findUnresolvedExplicitProfile(commandLineConfigOverrides);
   if (unresolvedProfile) {
+    const sourceLabel = commandLineConfigOverrides.global
+      ? `${getGlobalGslothDir()}/${GSLOTH_SETTINGS_DIR}/${unresolvedProfile}/`
+      : `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${unresolvedProfile}/`;
     return {
       // `found: true` so the caller renders THIS message. `found: false` means "nothing to
       // validate, run `gth init`", which would both discard the real diagnosis and misdirect a user
@@ -1710,10 +1771,13 @@ export async function validateConfig(
       ok: false,
       layers: [
         {
-          sourceLabel: `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${unresolvedProfile}/`,
+          sourceLabel,
           ok: false,
           warnings: [],
-          errorMessage: identityProfileNotFoundMessage(unresolvedProfile),
+          errorMessage: identityProfileNotFoundMessage(
+            unresolvedProfile,
+            commandLineConfigOverrides.global
+          ),
         },
       ],
     };
@@ -1726,7 +1790,7 @@ export async function validateConfig(
     const raw = await readRawConfigAtPath(discovered.path);
     const layer: ConfigLayerValidationReport = {
       sourceLabel: discovered.path,
-      ...validateRawGthConfig(raw, RAW_CONFIG_VALIDATION_OPTIONS),
+      ...validateRawGthConfig(raw, validationOptions),
     };
 
     // GS2-73 — mirror the run's `extends` resolution. GS2-41's `resolveConfigExtends` walks the
@@ -1760,12 +1824,35 @@ export async function validateConfig(
   // Global layer next: a run ALWAYS applies it (applyGlobalConfigBase in the project path,
   // loadGlobalRawConfig in the no-project path), so the diagnostic must validate it too — this is
   // the layer the previous single-layer validateConfig skipped whenever a project config existed.
-  const globalRaw = await loadGlobalRawConfigUnvalidated();
+  const globalRaw = await loadGlobalRawConfigUnvalidated(
+    commandLineConfigOverrides.identityProfile
+  );
   if (globalRaw) {
-    layers.push({
+    const layer: ConfigLayerValidationReport = {
       sourceLabel: globalRaw.label,
-      ...validateRawGthConfig(globalRaw.raw, RAW_CONFIG_VALIDATION_OPTIONS),
-    });
+      ...validateRawGthConfig(globalRaw.raw, validationOptions),
+    };
+
+    if (
+      commandLineConfigOverrides.global &&
+      layer.ok &&
+      typeof globalRaw.raw.extends === 'string'
+    ) {
+      try {
+        await composeExtends(globalRaw.raw, commandLineConfigOverrides.identityProfile, {
+          globalOnly: true,
+        });
+      } catch (e) {
+        if (e instanceof ConfigExtendsError || isConfigDiscoveryError(e)) {
+          layer.ok = false;
+          layer.errorMessage = e.message;
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    layers.push(layer);
   }
 
   // Vacuous-truth guard: `every` is true on an empty array, so gate `ok` on a config existing.

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1721,10 +1721,14 @@ export function findApprovalsRaterProfiles(raw: Record<string, unknown>): RaterP
  * loader (which hard-exits a real run) and {@link validateRawGthConfig} (which backs
  * `gth config validate`), so the validator can never green-light a config the runtime refuses.
  */
-export function unresolvedRaterProfileMessage(ref: RaterProfileRef): string {
+export function unresolvedRaterProfileMessage(ref: RaterProfileRef, searchedDir?: string): string {
+  // `searchedDir` is what the CALLER actually looked in. It is a parameter rather than a constant
+  // because a `--global` run searches `~/.gsloth/.gsloth-settings/<name>/`, and this module knows
+  // nothing of the filesystem; naming the project dir there would send the user to the wrong place.
+  const dir = searchedDir ?? `${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${ref.profile}/`;
   return (
     `identity profile "${ref.profile}" not found ` +
-    `(checked ${GSLOTH_DIR}/${GSLOTH_SETTINGS_DIR}/${ref.profile}/). ` +
+    `(checked ${dir}). ` +
     'Create it with `gth config profile create`, or omit approvals.rater to rate ' +
     'with the main model.'
   );
@@ -1761,6 +1765,12 @@ export interface RawConfigValidationOptions {
    * `approvals.rater.profile` existence check.
    */
   resolveProfile?: (profile: string) => boolean;
+  /**
+   * Renders the directory {@link resolveProfile} searched, for the failure message. Supplied by the
+   * loader, which alone knows whether this layer's profiles resolve in the project tree or under
+   * `~/.gsloth`; `undefined` (from the hook or the field) means the project location.
+   */
+  describeProfileDir?: (profile: string) => string | undefined;
 }
 
 export interface RawConfigValidationResult {
@@ -1843,7 +1853,10 @@ export function validateRawGthConfig(
         ok: false,
         warnings,
         errorMessage: formatIssueLines(
-          unresolved.map((ref) => ({ path: ref.path, message: unresolvedRaterProfileMessage(ref) }))
+          unresolved.map((ref) => ({
+            path: ref.path,
+            message: unresolvedRaterProfileMessage(ref, options.describeProfileDir?.(ref.profile)),
+          }))
         ),
       };
     }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -812,4 +812,11 @@ export interface CommandLineConfigOverrides {
    * to re-target its model.
    */
   model?: string;
+  /**
+   * Run with global configuration only, bypassing project-level configuration.
+   * When true, up-tree project config discovery is bypassed, loading configuration
+   * solely from ~/.gsloth/ (merged over default fallbacks).
+   * If paired with an identity profile, resolves under ~/.gsloth/.gsloth-settings/<name>/.
+   */
+  global?: boolean;
 }

--- a/packages/core/src/utils/globalConfigUtils.ts
+++ b/packages/core/src/utils/globalConfigUtils.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
-import { GSLOTH_DIR, GSLOTH_AUTH } from '#src/constants.js';
+import { GSLOTH_DIR, GSLOTH_SETTINGS_DIR, GSLOTH_AUTH } from '#src/constants.js';
 
 /**
  * Gets the global .gsloth directory path in the user's home directory
@@ -28,16 +28,26 @@ export function ensureGlobalGslothDir(): string {
 
 /**
  * Gets the read path for a global gsloth config file (e.g. `.gsloth.config.json`)
- * inside the global `~/.gsloth` directory. Reuses the same global folder as MCP auth.
+ * inside the global `~/.gsloth` directory (or `~/.gsloth/.gsloth-settings/<identityProfile>/`).
+ * Reuses the same global folder as MCP auth.
  *
  * This is a plain path resolver: it does NOT check for existence and does NOT create
  * the directory. Callers should guard with `existsSync` before reading.
  *
  * @param filename The configuration filename (e.g. `.gsloth.config.json`)
+ * @param identityProfileRaw Optional identity profile subdirectory name within `.gsloth-settings`
  * @returns The resolved path where the global configuration file would live
  */
-export function getGlobalGslothConfigReadPath(filename: string): string {
-  return resolve(getGlobalGslothDir(), filename);
+export function getGlobalGslothConfigReadPath(
+  filename: string,
+  identityProfileRaw?: string
+): string {
+  const globalDir = getGlobalGslothDir();
+  const identityProfile = identityProfileRaw?.trim();
+  if (identityProfile) {
+    return resolve(globalDir, GSLOTH_SETTINGS_DIR, identityProfile, filename);
+  }
+  return resolve(globalDir, filename);
 }
 
 /**

--- a/packages/core/src/utils/globalConfigUtils.ts
+++ b/packages/core/src/utils/globalConfigUtils.ts
@@ -27,6 +27,27 @@ export function ensureGlobalGslothDir(): string {
 }
 
 /**
+ * Composes the path a global config file would occupy inside an ARBITRARY global dir:
+ * `<globalDir>/<filename>`, or `<globalDir>/.gsloth-settings/<identityProfile>/<filename>` when a
+ * profile is named. Split out of {@link getGlobalGslothConfigReadPath} so the dir and the
+ * profile-segment rule are separable — a caller (or a test seam) that must substitute the global
+ * dir gets the real composition rule instead of reimplementing it and drifting from it.
+ *
+ * A blank/whitespace-only profile name counts as "no profile".
+ */
+export function resolveGlobalConfigPath(
+  globalDir: string,
+  filename: string,
+  identityProfileRaw?: string
+): string {
+  const identityProfile = identityProfileRaw?.trim();
+  if (identityProfile) {
+    return resolve(globalDir, GSLOTH_SETTINGS_DIR, identityProfile, filename);
+  }
+  return resolve(globalDir, filename);
+}
+
+/**
  * Gets the read path for a global gsloth config file (e.g. `.gsloth.config.json`)
  * inside the global `~/.gsloth` directory (or `~/.gsloth/.gsloth-settings/<identityProfile>/`).
  * Reuses the same global folder as MCP auth.
@@ -42,12 +63,7 @@ export function getGlobalGslothConfigReadPath(
   filename: string,
   identityProfileRaw?: string
 ): string {
-  const globalDir = getGlobalGslothDir();
-  const identityProfile = identityProfileRaw?.trim();
-  if (identityProfile) {
-    return resolve(globalDir, GSLOTH_SETTINGS_DIR, identityProfile, filename);
-  }
-  return resolve(globalDir, filename);
+  return resolveGlobalConfigPath(getGlobalGslothDir(), filename, identityProfileRaw);
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements `-g` / `--global` CLI flag to run Gaunt Sloth exclusively under user-level global configuration (`~/.gsloth/`), bypassing project-level configuration (`.gsloth.config.*`) and discovery per **CFG-56**.

### Changes
- **CLI Flag (`packages/app/src/cli.ts`):** Added `-g, --global` to global CLI options and propagated `global: true` to `CommandLineConfigOverrides`.
- **Config Types (`packages/core/src/config/types.ts`):** Added `global?: boolean` to `CommandLineConfigOverrides`.
- **Global Path Resolution (`packages/core/src/utils/globalConfigUtils.ts`):** Extended `getGlobalGslothConfigReadPath` with optional identity profile resolution (`~/.gsloth/.gsloth-settings/<name>/`).
- **Config Loader (`packages/core/src/config/loader.ts`):**
  - `findProjectConfigPath` returns `undefined` when `global` is active, bypassing project config discovery.
  - `resolveIdentityProfileConfigPath` supports `{ globalOnly: true }` to resolve named profiles strictly in global settings.
  - `resolveConfigExtends` propagates `globalOnly` through profile `extends` inheritance chains.
  - `initConfig` and `validateConfig` load and validate only the global layer when `global` is active.
- **Tests:**
  - Added `packages/core/spec/config.globalFlag.spec.ts` for unit coverage of flag overrides, profile resolution, extends composition, and missing profile validation.
  - Added `packages/app/spec/cliGlobalFlag.spec.ts` for CLI option parsing.
  - Added `packages/app/spec/configValidate.e2e.spec.ts` for e2e validation bypass testing.
